### PR TITLE
copr: fix missing suffix in built rpms

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -5,11 +5,12 @@ installdeps:
 
 srpm: installdeps
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
+	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-hosted-engine-ha.spec.in
 	mkdir -p tmp.repos
 	./autogen.sh --system --disable-python-syntax-check
 	make dist
 	rpmbuild \
 		-D "_topdir tmp.repos" \
-		-D "release_suffix ${SUFFIX}" \
 		-ts ./*.tar.gz
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
Imported from gerrit: https://gerrit.ovirt.org/c/ovirt-hosted-engine-ha/+/118017
Submittred by: @didib 

```
Change-Id: I95d02b5cae08e12d709fdbe90ff73083c07df1aa
Signed-off-by: Yedidyah Bar David <didi@redhat.com>
```