### PR TITLE
Mark temp repo directory as safe for COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,14 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
 	dnf -y install git autoconf automake make python3-devel
 
-srpm: installdeps
+git_cfg_safe:
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work because of the fix for CVE-2022-24765
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git_cfg_safe
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
 	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-hosted-engine-ha.spec.in


### PR DESCRIPTION
When building from COPR the project is cloned into a temporary directory,
which is not owned by the current user. From git 2.35.2 such a directory needs
to be marked as safe in order git commands to work correctly.

Signed-off-by: Asaf Rachmani <arachman@redhat.com>