### PR TITLE
copr: add make to buildrequirements

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           mkdir -p exported-artifacts
           mkdir -p tmp.repos
+          make check
+          make test
           ./autogen.sh --system
           coverage html \
             -d exported-artifacts/coverage_html_report \

--- a/ovirt-hosted-engine-ha.spec.in
+++ b/ovirt-hosted-engine-ha.spec.in
@@ -51,6 +51,7 @@ Requires:       python3-sanlock >= 3.7.3
 
 Requires:       python3-lxml
 
+BuildRequires:  make
 BuildRequires:  python3
 BuildRequires:  python3-devel
 


### PR DESCRIPTION
Due to make not being standard in centos10, add explicit buildrequirement.