### PR TITLE
core: use ConfigParser instead of SafeConfigParser

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,9 +48,9 @@ jobs:
         run: |
           mkdir -p exported-artifacts
           mkdir -p tmp.repos
+          ./autogen.sh --system
           make check
           make test
-          ./autogen.sh --system
           coverage html \
             -d exported-artifacts/coverage_html_report \
             --rcfile="${PWD}/automation/coverage.rc"

--- a/ovirt_hosted_engine_ha/agent/hosted_engine.py
+++ b/ovirt_hosted_engine_ha/agent/hosted_engine.py
@@ -195,7 +195,7 @@ class HostedEngine(object):
             'cpu-load-penalty-max'
         ))
 
-        cfg = configparser.SafeConfigParser()
+        cfg = configparser.ConfigParser()
         cfg.read(constants.AGENT_CONF_FILE)
         try:
             score.update(cfg.items('score'))

--- a/ovirt_hosted_engine_ha/broker/notifications.py
+++ b/ovirt_hosted_engine_ha/broker/notifications.py
@@ -3,10 +3,7 @@ from email.utils import formatdate
 import socket
 
 import smtplib
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+import configparser
 import re
 import os
 import logging
@@ -54,7 +51,7 @@ def notify(type, detail, options):
 
     heconf = config.Config(logger=logger)
     path = heconf.refresh_local_conf_file(config.BROKER)
-    cfg = configparser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.read(path)
 
     try:

--- a/ovirt_hosted_engine_ha/env/config_ini.py
+++ b/ovirt_hosted_engine_ha/env/config_ini.py
@@ -1,7 +1,4 @@
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+import configparser
 
 from ovirt_hosted_engine_ha.env.config_shared import SharedConfigFile
 
@@ -17,7 +14,7 @@ class SharedIniFile(SharedConfigFile):
             writable=writable,
             rawonly=False,
             logger=logger)
-        self._conf = configparser.SafeConfigParser()
+        self._conf = configparser.ConfigParser()
 
     def _prepare_key(self, key):
         if "." not in key:


### PR DESCRIPTION
The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. Using ConfigParser directly instead. Also updated imports due to configparser being a standard library in Python 3.